### PR TITLE
Update state.json

### DIFF
--- a/lib/state.json
+++ b/lib/state.json
@@ -19570,6 +19570,11 @@
 		"country_id": "231"
 	},
 	{
+		"id": "3929",
+		"name": "District of Columbia",
+		"country_id": "231"
+	},
+	{
 		"id": "3930",
 		"name": "Florida",
 		"country_id": "231"


### PR DESCRIPTION
Added District of Columbia to list of States under country id 231 (the United States of America)

https://www.usa.gov/state-government/district-of-columbia