### PR TITLE
Bugfix. Fixed interfaces import ICountry, IState, ICity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import Country from './country';
 import State from './state';
 import City from './city';
-import { ICountry, IState, ICity, Timezones } from './interface';
+import { ICountry, IState, ICity } from './interface';
 
 export { Country };
 export { State };
 export { City };
-export { ICountry, IState, ICity, Timezones };
+export { ICountry, IState, ICity };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import Country from './country';
 import State from './state';
 import City from './city';
+import { ICountry, IState, ICity, Timezones } from './interface';
 
 export { Country };
 export { State };
 export { City };
+export { ICountry, IState, ICity, Timezones };


### PR DESCRIPTION
Fixed interfaces imported by Documents 

```
// Latest version - v3.0.0 with Tree Shaking to reduce bundle size
// Import Interfaces`
import { ICountry, IState, ICity } from 'country-state-city'
```
And fixed issue in this [comment](https://github.com/harpreetkhalsagtbit/country-state-city/pull/15#issuecomment-873536877) 