### PR TITLE
Fix type definitions not loading properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library for fetching Country, its States and Cities",
   "main": "./lib/cjs/index.js",
   "module": "./lib/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./lib/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
### The Issue
Importing any function from the package doesn't automatically import the type definitions as well.

Example:
```typescript
import { City } from 'country-state-city'; // Could not find a declaration file for module 'country-state-city'. 
```
### Context
In this [commit](https://github.com/harpreetkhalsagtbit/country-state-city/commit/80987a78f8725e2ef08b45e5e333afcbf1501ba5) the `outDir` changed from `dist` to `lib`.
the `types` in `package.json` should be changed from `dist/index.d.ts` to `./lib/index.d.ts`
