### PR TITLE
add export for city and country functions

### DIFF
--- a/src/city.ts
+++ b/src/city.ts
@@ -3,12 +3,12 @@ import { compare } from './utils';
 import { ICity } from './interface';
 
 // Get a list of all cities.
-function getAllCities() {
+export function getAllCities() {
 	return cityList;
 }
 
 // Get a list of cities belonging to a specific state and country.
-function getCitiesOfState(countryCode: string, stateCode: string): ICity[] {
+export function getCitiesOfState(countryCode: string, stateCode: string): ICity[] {
 	if (!stateCode) return [];
 	if (!countryCode) return [];
 
@@ -20,7 +20,7 @@ function getCitiesOfState(countryCode: string, stateCode: string): ICity[] {
 }
 
 // Get a list of cities belonging to a specific country.
-function getCitiesOfCountry(countryCode: string): ICity[] | undefined {
+export function getCitiesOfCountry(countryCode: string): ICity[] | undefined {
 	if (!countryCode) return [];
 
 	const cities = cityList.filter((value: { countryCode: string }) => {

--- a/src/country.ts
+++ b/src/country.ts
@@ -3,14 +3,14 @@ import { findEntryByCode } from './utils';
 import { ICountry } from './interface';
 
 // Get a country by isoCode.
-function getCountryByCode(isoCode: string): ICountry | undefined {
+export function getCountryByCode(isoCode: string): ICountry | undefined {
 	if (!isoCode) return undefined;
 
 	return findEntryByCode(countryList, isoCode);
 }
 
 // Get a list of all countries.
-function getAllCountries(): ICountry[] {
+export function getAllCountries(): ICountry[] {
 	return countryList;
 }
 


### PR DESCRIPTION
A workaround for issue #123 requires importing functions directly but this only works for `State` functions which are exported by default. This PR adds exports to `City` and `Country`