### PR TITLE
Correcting 4 States latitude/longitude

### DIFF
--- a/.backupdata/state.json
+++ b/.backupdata/state.json
@@ -17958,8 +17958,8 @@
         "name": "South Holland",
         "isoCode": "ZH",
         "countryCode": "NL",
-        "latitude": "41.60086810",
-        "longitude": "-87.60698940"
+        "latitude": "51.9966792",
+        "longitude": "4.5597397"
     },
     {
         "name": "Limburg",

--- a/.backupdata/state.json
+++ b/.backupdata/state.json
@@ -11378,8 +11378,8 @@
         "name": "Marche",
         "isoCode": "57",
         "countryCode": "IT",
-        "latitude": "30.55670700",
-        "longitude": "-81.44930300"
+        "latitude": "43.30456200",
+        "longitude": "13.71947000"
     },
     {
         "name": "Metropolitan City of Reggio Calabria",

--- a/.backupdata/state.json
+++ b/.backupdata/state.json
@@ -9376,8 +9376,8 @@
         "name": "West Flanders",
         "isoCode": "VWV",
         "countryCode": "BE",
-        "latitude": "40.01793340",
-        "longitude": "-105.28067330"
+        "latitude": "51.0404747",
+        "longitude": "2.9994213"
     },
     {
         "name": "Liège",

--- a/.backupdata/state.json
+++ b/.backupdata/state.json
@@ -11434,8 +11434,8 @@
         "name": "Lazio",
         "isoCode": "62",
         "countryCode": "IT",
-        "latitude": "45.69916670",
-        "longitude": "-73.65583330"
+        "latitude": "41.81224100",
+        "longitude": "12.73851000"
     },
     {
         "name": "Abruzzo",

--- a/.backupdata/state2.json
+++ b/.backupdata/state2.json
@@ -17958,8 +17958,8 @@
         "name": "South Holland",
         "isoCode": "ZH",
         "countryCode": "NL",
-        "latitude": "41.60086810",
-        "longitude": "-87.60698940"
+        "latitude": "51.9966792",
+        "longitude": "4.5597397"
     },
     {
         "name": "Limburg",

--- a/.backupdata/state2.json
+++ b/.backupdata/state2.json
@@ -11378,8 +11378,8 @@
         "name": "Marche",
         "isoCode": "57",
         "countryCode": "IT",
-        "latitude": "30.55670700",
-        "longitude": "-81.44930300"
+        "latitude": "43.30456200",
+        "longitude": "13.71947000"
     },
     {
         "name": "Metropolitan City of Reggio Calabria",

--- a/.backupdata/state2.json
+++ b/.backupdata/state2.json
@@ -9376,8 +9376,8 @@
         "name": "West Flanders",
         "isoCode": "VWV",
         "countryCode": "BE",
-        "latitude": "40.01793340",
-        "longitude": "-105.28067330"
+        "latitude": "51.0404747",
+        "longitude": "2.9994213"
     },
     {
         "name": "Liège",

--- a/.backupdata/state2.json
+++ b/.backupdata/state2.json
@@ -11434,8 +11434,8 @@
         "name": "Lazio",
         "isoCode": "62",
         "countryCode": "IT",
-        "latitude": "45.69916670",
-        "longitude": "-73.65583330"
+        "latitude": "41.81224100",
+        "longitude": "12.73851000"
     },
     {
         "name": "Abruzzo",

--- a/data/Belgium-BE/allStates.geo.json
+++ b/data/Belgium-BE/allStates.geo.json
@@ -80,8 +80,8 @@
       "name": "West Flanders",
       "isoCode": "VWV",
       "countryCode": "BE",
-      "latitude": "40.01793340",
-      "longitude": "-105.28067330"
+      "latitude": "51.0404747",
+      "longitude": "2.9994213"
    },
    {
       "name": "Liège",

--- a/data/Italy-IT/allStates.geo.json
+++ b/data/Italy-IT/allStates.geo.json
@@ -45,8 +45,8 @@
       "name": "Marche",
       "isoCode": "57",
       "countryCode": "IT",
-      "latitude": "30.55670700",
-      "longitude": "-81.44930300"
+      "latitude": "43.30456200",
+      "longitude": "13.71947000"
    },
    {
       "name": "Metropolitan City of Reggio Calabria",
@@ -101,8 +101,8 @@
       "name": "Lazio",
       "isoCode": "62",
       "countryCode": "IT",
-      "latitude": "45.69916670",
-      "longitude": "-73.65583330"
+      "latitude": "41.81224100",
+      "longitude": "12.73851000"
    },
    {
       "name": "Abruzzo",

--- a/data/Netherlands-NL/allStates.geo.json
+++ b/data/Netherlands-NL/allStates.geo.json
@@ -31,8 +31,8 @@
       "name": "South Holland",
       "isoCode": "ZH",
       "countryCode": "NL",
-      "latitude": "41.60086810",
-      "longitude": "-87.60698940"
+      "latitude": "51.9966792",
+      "longitude": "4.5597397"
    },
    {
       "name": "Limburg",

--- a/data/allStatesNested.geo.json
+++ b/data/allStatesNested.geo.json
@@ -11684,8 +11684,8 @@
          "name": "Marche",
          "isoCode": "57",
          "countryCode": "IT",
-         "latitude": "30.55670700",
-         "longitude": "-81.44930300"
+         "latitude": "43.30456200",
+         "longitude": "13.71947000"
       },
       {
          "name": "Metropolitan City of Reggio Calabria",

--- a/data/allStatesNested.geo.json
+++ b/data/allStatesNested.geo.json
@@ -9632,8 +9632,8 @@
          "name": "West Flanders",
          "isoCode": "VWV",
          "countryCode": "BE",
-         "latitude": "40.01793340",
-         "longitude": "-105.28067330"
+         "latitude": "51.0404747",
+         "longitude": "2.9994213"
       },
       {
          "name": "Liège",

--- a/data/allStatesNested.geo.json
+++ b/data/allStatesNested.geo.json
@@ -11740,8 +11740,8 @@
          "name": "Lazio",
          "isoCode": "62",
          "countryCode": "IT",
-         "latitude": "45.69916670",
-         "longitude": "-73.65583330"
+         "latitude": "41.81224100",
+         "longitude": "12.73851000"
       },
       {
          "name": "Abruzzo",

--- a/data/allStatesNested.geo.json
+++ b/data/allStatesNested.geo.json
@@ -18364,8 +18364,8 @@
          "name": "South Holland",
          "isoCode": "ZH",
          "countryCode": "NL",
-         "latitude": "41.60086810",
-         "longitude": "-87.60698940"
+         "latitude": "51.9966792",
+         "longitude": "4.5597397"
       },
       {
          "name": "Limburg",

--- a/src/assets/state.json
+++ b/src/assets/state.json
@@ -9523,8 +9523,8 @@
       "name": "West Flanders",
       "isoCode": "VWV",
       "countryCode": "BE",
-      "latitude": "40.01793340",
-      "longitude": "-105.28067330"
+      "latitude": "51.0404747",
+      "longitude": "2.9994213"
    },
    {
       "name": "Liège",

--- a/src/assets/state.json
+++ b/src/assets/state.json
@@ -18175,8 +18175,8 @@
       "name": "South Holland",
       "isoCode": "ZH",
       "countryCode": "NL",
-      "latitude": "41.60086810",
-      "longitude": "-87.60698940"
+      "latitude": "51.9966792",
+      "longitude": "4.5597397"
    },
    {
       "name": "Limburg",

--- a/src/assets/state.json
+++ b/src/assets/state.json
@@ -11553,8 +11553,8 @@
       "name": "Marche",
       "isoCode": "57",
       "countryCode": "IT",
-      "latitude": "30.55670700",
-      "longitude": "-81.44930300"
+      "latitude": "43.30456200",
+      "longitude": "13.71947000"
    },
    {
       "name": "Metropolitan City of Reggio Calabria",

--- a/src/assets/state.json
+++ b/src/assets/state.json
@@ -11609,8 +11609,8 @@
       "name": "Lazio",
       "isoCode": "62",
       "countryCode": "IT",
-      "latitude": "45.69916670",
-      "longitude": "-73.65583330"
+      "latitude": "41.81224100",
+      "longitude": "12.73851000"
    },
    {
       "name": "Abruzzo",


### PR DESCRIPTION
Some states were not properly geo coded (lat/long)
* IT - Lazio was coded in US
* IT - Marche was coded in US
* NL - South Holland was coded in US (with the same lat/long as US - South Holland place)
* BE - West Flanders was coded in US