### PR TITLE
Updated the names of changed US Army bases.

### DIFF
--- a/data/United_States-US/Alabama-AL/allCities.geo.json
+++ b/data/United_States-US/Alabama-AL/allCities.geo.json
@@ -959,7 +959,7 @@
       "longitude": "-85.71969000"
    },
    {
-      "name": "Fort Rucker",
+      "name": "Fort Novosel",
       "countryCode": "US",
       "stateCode": "AL",
       "latitude": "31.34282000",

--- a/data/United_States-US/Alabama-AL/allCities.lite.json
+++ b/data/United_States-US/Alabama-AL/allCities.lite.json
@@ -685,7 +685,7 @@
       "stateCode": "AL"
    },
    {
-      "name": "Fort Rucker",
+      "name": "Fort Novosel",
       "countryCode": "US",
       "stateCode": "AL"
    },

--- a/data/United_States-US/Louisiana-LA/allCities.geo.json
+++ b/data/United_States-US/Louisiana-LA/allCities.geo.json
@@ -763,14 +763,14 @@
       "longitude": "-91.55456000"
    },
    {
-      "name": "Fort Polk North",
+      "name": "Fort Johnson North",
       "countryCode": "US",
       "stateCode": "LA",
       "latitude": "31.10302000",
       "longitude": "-93.17913000"
    },
    {
-      "name": "Fort Polk South",
+      "name": "Fort Johnson South",
       "countryCode": "US",
       "stateCode": "LA",
       "latitude": "31.05110000",

--- a/data/United_States-US/Louisiana-LA/allCities.lite.json
+++ b/data/United_States-US/Louisiana-LA/allCities.lite.json
@@ -545,12 +545,12 @@
       "stateCode": "LA"
    },
    {
-      "name": "Fort Polk North",
+      "name": "Fort Johnson North",
       "countryCode": "US",
       "stateCode": "LA"
    },
    {
-      "name": "Fort Polk South",
+      "name": "Fort Johnson South",
       "countryCode": "US",
       "stateCode": "LA"
    },

--- a/data/United_States-US/North_Carolina-NC/allCities.geo.json
+++ b/data/United_States-US/North_Carolina-NC/allCities.geo.json
@@ -1162,7 +1162,7 @@
       "longitude": "-80.25636000"
    },
    {
-      "name": "Fort Bragg",
+      "name": "Fort Liberty",
       "countryCode": "US",
       "stateCode": "NC",
       "latitude": "35.13900000",

--- a/data/United_States-US/North_Carolina-NC/allCities.lite.json
+++ b/data/United_States-US/North_Carolina-NC/allCities.lite.json
@@ -830,7 +830,7 @@
       "stateCode": "NC"
    },
    {
-      "name": "Fort Bragg",
+      "name": "Fort Liberty",
       "countryCode": "US",
       "stateCode": "NC"
    },

--- a/data/United_States-US/Texas-TX/allCities.geo.json
+++ b/data/United_States-US/Texas-TX/allCities.geo.json
@@ -2667,7 +2667,7 @@
       "longitude": "-105.84525000"
    },
    {
-      "name": "Fort Hood",
+      "name": "Fort Cavazos",
       "countryCode": "US",
       "stateCode": "TX",
       "latitude": "31.13489000",

--- a/data/United_States-US/Texas-TX/allCities.lite.json
+++ b/data/United_States-US/Texas-TX/allCities.lite.json
@@ -1905,7 +1905,7 @@
       "stateCode": "TX"
    },
    {
-      "name": "Fort Hood",
+      "name": "Fort Cavazos",
       "countryCode": "US",
       "stateCode": "TX"
    },

--- a/data/United_States-US/Virginia-VA/allCities.geo.json
+++ b/data/United_States-US/Virginia-VA/allCities.geo.json
@@ -1435,7 +1435,7 @@
       "longitude": "-77.05803000"
    },
    {
-      "name": "Fort Lee",
+      "name": "Fort Gregg-Adams",
       "countryCode": "US",
       "stateCode": "VA",
       "latitude": "37.24694000",

--- a/data/United_States-US/Virginia-VA/allCities.lite.json
+++ b/data/United_States-US/Virginia-VA/allCities.lite.json
@@ -1025,7 +1025,7 @@
       "stateCode": "VA"
    },
    {
-      "name": "Fort Lee",
+      "name": "Fort Gregg-Adams",
       "countryCode": "US",
       "stateCode": "VA"
    },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "country-state-city",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"description": "Library for fetching Country, its States and Cities",
 	"main": "./lib/cjs/index.js",
 	"module": "./lib/index.js",


### PR DESCRIPTION
Modified the names of Fort Rucker, Fort Polk, Fort Bragg, Fort Hood, and Fort Lee per https://impactaid.ed.gov/army-installation-name-changes/ and https://www.jbsa.mil/News/News/Article/3363020/dod-to-change-names-of-nine-army-installations-by-2024/

resolves #190 